### PR TITLE
Modification

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -33,6 +33,16 @@ return [
         'local' => [
             'driver' => 'local',
             'root' => storage_path('app'),
+            'permissions' => [
+                'file' => [
+                    'public' => 0644,
+                    'private' => 0644,
+                ],
+                'dir' => [
+                    'public' => 0755,
+                    'private' => 0755,
+                ],
+            ],
         ],
 
         'public' => [

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,12 @@ use App\Http\Controllers\UploadController;
 |
 */
 
+Route::get('/link-storage', function () {
+    Artisan::call('storage:link'); // this will do the command line job
+    return('Storage Link Successfull');
+});
+
+
 Route::get('/', function () {
     return redirect()->route('login');
 });


### PR DESCRIPTION
For shared hosting server with no-terminal access, php artisan storage:link  can be run through a GET request.
For default folder permission as 755 to all newly created subfolders inside public/invoices , permissions have been added to config/filesystems.php